### PR TITLE
Switch build status to SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 **IMPORTANT**: Since version 1.3.0, this is the main repository of Grease. Versions older than 1.1.9 can be found in the [Smalltalkhub repository](http://www.smalltalkhub.com/#!/~Seaside/Grease11). Check out the [releases list](https://github.com/SeasideSt/Grease/releases) for all version numbers in this repository.
 
-The Grease Portability Library  [![Build Status](https://travis-ci.org/SeasideSt/Grease.png?branch=master)](https://travis-ci.org/SeasideSt/Grease)
+The Grease Portability Library  [![Build Status](https://travis-ci.org/SeasideSt/Grease.svg?branch=master)](https://travis-ci.org/SeasideSt/Grease)
 ======
 Grease enhances the ANSI Smalltalk standard. With only a few exceptions, we assume platforms are fully ANSI-compliant. Platforms want to support Seaside and standardization makes this easier for the project’s developers and its porters.
 


### PR DESCRIPTION
Switch build status to SVG so it's not blurry on high res displays.