### PR TITLE
Improve travis builds (remove caching where it breaks)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ smalltalk:
   - Pharo-3.0
   - Squeak-trunk
   - Squeak-5.1
-  - GemStone-3.1.0.6
-  - GemStone-3.2.16
-  - GemStone-3.3.4
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,21 @@ smalltalk:
   - GemStone-3.1.0.6
   - GemStone-3.2.16
   - GemStone-3.3.4
-cache:
-  directories:
-    - $SMALLTALK_CI_CACHE
+
 matrix:
   allow_failures:
     - smalltalk: Pharo-alpha
     - smalltalk: Squeak-trunk
+  include:
+    - smalltalk: GemStone-3.1.0.6
+      cache:
+        directories:
+          - $SMALLTALK_CI_CACHE
+    - smalltalk: GemStone-3.2.16
+      cache:
+        directories:
+          - $SMALLTALK_CI_CACHE
+    - smalltalk: GemStone-3.3.4
+      cache:
+        directories:
+          - $SMALLTALK_CI_CACHE


### PR DESCRIPTION
Remove the use of caches for Pharo and Squeak builds: the builds fail when starting from cached disks because the download of the vm and image fails. They are also not that useful for Pharo builds according to the Smalltalk-CI docs.