### PR TITLE
added Pharo 9 to baseline

### DIFF
--- a/repository/BaselineOfGrease.package/BaselineOfGrease.class/instance/baselinePharo..st
+++ b/repository/BaselineOfGrease.package/BaselineOfGrease.class/instance/baselinePharo..st
@@ -29,7 +29,7 @@ baselinePharo: spec
 				package: 'Grease-Pharo60-Core' with: [ spec requires: #('Grease-Core') ] ].
 
 	spec
-		for: #(#'pharo7.x' #'pharo8.x')
+		for: #(#'pharo7.x' #'pharo8.x' #'pharo9.x')
 		do: [ spec
 				package: 'Grease-Core' with: [ spec includes: #('Grease-Pharo70-Core') ];
 				package: 'Grease-Tests-Core'


### PR DESCRIPTION
Updated baseline so that Grease loads correctly into Pharo 9.
Solves #98 