### PR TITLE
add tmate debug step in CI build for GS3.4.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,9 @@ jobs:
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:
           smalltalk-image: ${{ matrix.smalltalk }}
-      # - name: Fix missing OS prerequisites for GemStone builds
-      #   run: |
-      #     git clone https://github.com/GsDevKit/GsDevKit_home.git
-      #     ./GsDevKit_home/bin/utils/installOsPrereqs
-      #   continue-on-error: true
-      #   if: startsWith(matrix.smalltalk,'GemStone')
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: matrix.smalltalk == 'GemStone64-3.4.5'
       - name: Run tests
         run: smalltalkci -s ${{ matrix.smalltalk }}
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:
           smalltalk-image: ${{ matrix.smalltalk }}
+      - name: Sleep...
+        run: sleep 20
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: matrix.smalltalk == 'GemStone64-3.4.5'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,14 @@ jobs:
       - uses: hpi-swa/setup-smalltalkCI@v1
         with:
           smalltalk-image: ${{ matrix.smalltalk }}
-      - name: Sleep...
-        run: sleep 20
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-        if: matrix.smalltalk == 'GemStone64-3.4.5'
+      - name: Ensure lookups for current hostname are handled
+        run: |
+          echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
+      # - name: Sleep...
+      #   run: sleep 20
+      # - name: Setup tmate session
+      #   uses: mxschmitt/action-tmate@v3
+      #   if: matrix.smalltalk == 'GemStone64-3.4.5'
       - name: Run tests
         run: smalltalkci -s ${{ matrix.smalltalk }}
         shell: bash


### PR DESCRIPTION
Debugging github actions with tmate... doing a PR seems to be the most 'reliable' method to get to the log so you can see the tmate session url... (https://github.com/mxschmitt/action-tmate/issues/1)