### PR TITLE
Introduce greaseBeginsWith: and greaseEndsWith:

### DIFF
--- a/repository/Grease-GemStone-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
+++ b/repository/Grease-GemStone-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
@@ -1,0 +1,5 @@
+*grease-gemstone-core
+greaseBeginsWith: aSequenceableCollection
+
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self beginsWith: aSequenceableCollection

--- a/repository/Grease-GemStone-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
+++ b/repository/Grease-GemStone-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
@@ -1,0 +1,5 @@
+*grease-gemstone-core
+greaseEndsWith: aSequenceableCollection
+
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self endsWith: aSequenceableCollection

--- a/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/beginsWithSubCollection..st
+++ b/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/beginsWithSubCollection..st
@@ -1,4 +1,8 @@
 *Grease-Pharo100-Core
 beginsWithSubCollection: aSequenceableCollection
 	"Some platforms implement #beginsWith: to answer true for an empty argument."
+	self
+		greaseDeprecatedApi: 'SequenceableCollection>>#beginsWithSubCollection:'
+		details: 'Use SequenceableCollection>>#greaseBegins:'.
+	aSequenceableCollection isEmpty ifTrue: [ ^ false ].
 	^ self beginsWith: aSequenceableCollection

--- a/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/endsWithSubCollection..st
+++ b/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/endsWithSubCollection..st
@@ -1,4 +1,8 @@
 *Grease-Pharo100-Core
 endsWithSubCollection: aSequenceableCollection
 	"Some platforms implement #endsWith: to answer true for an empty argument."
+	self
+		greaseDeprecatedApi: 'SequenceableCollection>>#endsWithSubCollection:'
+		details: 'Use SequenceableCollection>>#greaseEndsWith:'.
+	aSequenceableCollection isEmpty ifTrue: [ ^ false ].
 	^ self endsWith: aSequenceableCollection

--- a/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
+++ b/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
@@ -1,0 +1,4 @@
+*Grease-Pharo100-Core
+greaseBeginsWith: aSequenceableCollection
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self beginsWith: aSequenceableCollection

--- a/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
+++ b/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
@@ -1,4 +1,5 @@
 *Grease-Pharo100-Core
 greaseBeginsWith: aSequenceableCollection
+
 	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
 	^ self beginsWith: aSequenceableCollection

--- a/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
+++ b/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
@@ -1,4 +1,5 @@
 *Grease-Pharo100-Core
 greaseEndsWith: aSequenceableCollection
+
 	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
 	^ self endsWith: aSequenceableCollection

--- a/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
+++ b/repository/Grease-Pharo100-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
@@ -1,0 +1,4 @@
+*Grease-Pharo100-Core
+greaseEndsWith: aSequenceableCollection
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self endsWith: aSequenceableCollection

--- a/repository/Grease-Pharo40-Slime.package/GRNotPortableCollectionsRule.class/instance/initialize.st
+++ b/repository/Grease-Pharo40-Slime.package/GRNotPortableCollectionsRule.class/instance/initialize.st
@@ -3,6 +3,6 @@ initialize
 	super initialize.
 	self rewriteRule
 		replace: '`@collection beginsWith: `@subCollection'
-			with: '`@collection beginsWithSubCollection: `@subCollection';
+			with: '`@collection greaseBeginsWith: `@subCollection';
 		replace: '`@collection endsWith: `@subCollection'
-			with: '`@collection endsWithSubCollection: `@subCollection'
+			with: '`@collection greaseEndsWith: `@subCollection'

--- a/repository/Grease-Pharo70-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
+++ b/repository/Grease-Pharo70-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
@@ -1,0 +1,5 @@
+*Grease-Pharo70-Core
+greaseBeginsWith: aSequenceableCollection
+
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self beginsWith: aSequenceableCollection

--- a/repository/Grease-Pharo70-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
+++ b/repository/Grease-Pharo70-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
@@ -1,0 +1,5 @@
+*Grease-Pharo70-Core
+greaseEndsWith: aSequenceableCollection
+
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self endsWith: aSequenceableCollection

--- a/repository/Grease-Pharo90-Core.package/SequenceableCollection.extension/instance/beginsWithSubCollection..st
+++ b/repository/Grease-Pharo90-Core.package/SequenceableCollection.extension/instance/beginsWithSubCollection..st
@@ -1,4 +1,8 @@
 *Grease-Pharo90-Core
 beginsWithSubCollection: aSequenceableCollection
+
+	self
+		greaseDeprecatedApi: 'SequenceableCollection>>#beginsWithSubCollection:'
+		details: 'Use SequenceableCollection>>#greaseBeginsWith:'.
 	"Some platforms implement #beginsWith: to answer true for an empty argument."
 	^ self beginsWith: aSequenceableCollection

--- a/repository/Grease-Pharo90-Core.package/SequenceableCollection.extension/instance/endsWithSubCollection..st
+++ b/repository/Grease-Pharo90-Core.package/SequenceableCollection.extension/instance/endsWithSubCollection..st
@@ -1,4 +1,8 @@
 *Grease-Pharo90-Core
 endsWithSubCollection: aSequenceableCollection
+
+	self
+		greaseDeprecatedApi: 'SequenceableCollection>>#endsWithSubCollection:'
+		details: 'Use SequenceableCollection>>#greaseEndsWith:'.
 	"Some platforms implement #endsWith: to answer true for an empty argument."
 	^ self endsWith: aSequenceableCollection

--- a/repository/Grease-Pharo90-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
+++ b/repository/Grease-Pharo90-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
@@ -1,0 +1,5 @@
+*Grease-Pharo90-Core
+greaseBeginsWith: aSequenceableCollection
+
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self beginsWith: aSequenceableCollection

--- a/repository/Grease-Pharo90-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
+++ b/repository/Grease-Pharo90-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
@@ -1,0 +1,5 @@
+*Grease-Pharo90-Core
+greaseEndsWith: aSequenceableCollection
+
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self endsWith: aSequenceableCollection

--- a/repository/Grease-Pharo90-Slime.package/GRNotPortableCollectionsRule.class/instance/initialize.st
+++ b/repository/Grease-Pharo90-Slime.package/GRNotPortableCollectionsRule.class/instance/initialize.st
@@ -3,6 +3,6 @@ initialize
 	super initialize.
 	self rewriteRule
 		replace: '`@collection beginsWith: `@subCollection'
-			with: '`@collection beginsWithSubCollection: `@subCollection';
+			with: '`@collection greaseBeginsWith: `@subCollection';
 		replace: '`@collection endsWith: `@subCollection'
-			with: '`@collection endsWithSubCollection: `@subCollection'
+			with: '`@collection greaseEndsWith: `@subCollection'

--- a/repository/Grease-Slime.package/GRNotPortableCollectionsRule.class/instance/initialize.st
+++ b/repository/Grease-Slime.package/GRNotPortableCollectionsRule.class/instance/initialize.st
@@ -3,6 +3,6 @@ initialize
 	super initialize.
 	self rewriteRule
 		replace: '`@collection beginsWith: `@subCollection'
-			with: '`@collection beginsWithSubCollection: `@subCollection';
+			with: '`@collection greaseBeginsWith: `@subCollection';
 		replace: '`@collection endsWith: `@subCollection'
-			with: '`@collection endsWithSubCollection: `@subCollection'
+			with: '`@collection greaseEndsWith: `@subCollection'

--- a/repository/Grease-Squeak5-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
+++ b/repository/Grease-Squeak5-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
@@ -1,0 +1,5 @@
+*grease-squeak5-core
+greaseBeginsWith: aSequenceableCollection
+
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self beginsWith: aSequenceableCollection

--- a/repository/Grease-Squeak5-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
+++ b/repository/Grease-Squeak5-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
@@ -1,0 +1,5 @@
+*grease-squeak5-core
+greaseEndsWith: aSequenceableCollection
+
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self endsWith: aSequenceableCollection

--- a/repository/Grease-Squeak6-Core.package/SequenceableCollection.extension/instance/beginsWithSubCollection..st
+++ b/repository/Grease-Squeak6-Core.package/SequenceableCollection.extension/instance/beginsWithSubCollection..st
@@ -1,4 +1,8 @@
 *grease-squeak6-core
 beginsWithSubCollection: aSequenceableCollection
+	self
+		greaseDeprecatedApi: 'SequenceableCollection>>#beginsWithSubCollection:'
+		details: 'Use SequenceableCollection>>#greaseBeginsWith:'.
 	"Some platforms implement #beginsWith: to answer true for an empty argument."
+	aSequenceableCollection isEmpty ifTrue: [ ^ false ].
 	^ self beginsWith: aSequenceableCollection

--- a/repository/Grease-Squeak6-Core.package/SequenceableCollection.extension/instance/endsWithSubCollection..st
+++ b/repository/Grease-Squeak6-Core.package/SequenceableCollection.extension/instance/endsWithSubCollection..st
@@ -1,4 +1,8 @@
 *grease-squeak6-core
 endsWithSubCollection: aSequenceableCollection
+	self
+		greaseDeprecatedApi: 'SequenceableCollection>>#endsWithSubCollection:'
+		details: 'Use SequenceableCollection>>#greaseEndsWith:'.
 	"Some platforms implement #endsWith: to answer true for an empty argument."
+	aSequenceableCollection isEmpty ifTrue: [ ^ false ].
 	^ self endsWith: aSequenceableCollection

--- a/repository/Grease-Squeak6-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
+++ b/repository/Grease-Squeak6-Core.package/SequenceableCollection.extension/instance/greaseBeginsWith..st
@@ -1,0 +1,5 @@
+*grease-squeak6-core
+greaseBeginsWith: aSequenceableCollection
+
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self beginsWith: aSequenceableCollection

--- a/repository/Grease-Squeak6-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
+++ b/repository/Grease-Squeak6-Core.package/SequenceableCollection.extension/instance/greaseEndsWith..st
@@ -1,0 +1,5 @@
+*grease-squeak6-core
+greaseEndsWith: aSequenceableCollection
+
+	aSequenceableCollection isEmpty ifTrue: [ ^ true ].
+	^ self endsWith: aSequenceableCollection

--- a/repository/Grease-Tests-Core.package/GRAbstractSequenceableCollectionTest.class/instance/testGreaseBeginsWith.st
+++ b/repository/Grease-Tests-Core.package/GRAbstractSequenceableCollectionTest.class/instance/testGreaseBeginsWith.st
@@ -1,0 +1,9 @@
+tests
+testGreaseBeginsWith
+	| collection |
+	collection := self arbitraryCollection.
+	self assert: (collection greaseBeginsWith: (collection copyWithout: collection last)).
+	self assert: (collection greaseBeginsWith: collection).
+	self deny: (collection greaseBeginsWith: (collection copyWith: collection first)).
+	self assert: (collection greaseBeginsWith: self emptyCollection).
+	self deny: (self emptyCollection greaseBeginsWith: collection)

--- a/repository/Grease-Tests-Core.package/GRAbstractSequenceableCollectionTest.class/instance/testGreaseEndsWith.st
+++ b/repository/Grease-Tests-Core.package/GRAbstractSequenceableCollectionTest.class/instance/testGreaseEndsWith.st
@@ -1,0 +1,9 @@
+tests
+testGreaseEndsWith
+	| collection |
+	collection := self arbitraryCollection.
+	self assert: (collection greaseEndsWith: (collection copyWithout: collection first)).
+	self assert: (collection greaseEndsWith: collection).
+	self deny: (collection greaseEndsWith: (collection copyWith: collection first)).
+	self assert: (collection greaseEndsWith: self emptyCollection).
+	self deny: (self emptyCollection greaseEndsWith: collection)

--- a/repository/Grease-Tests-Slime.package/GRSlimeTest.class/instance/testNotPortableCollectionsRule.st
+++ b/repository/Grease-Tests-Slime.package/GRSlimeTest.class/instance/testNotPortableCollectionsRule.st
@@ -9,5 +9,5 @@ testNotPortableCollectionsRule
 	self 
 		runTransformation: GRNotPortableCollectionsRule
 		changes: #(
-			'beginsWith1 ''abc'' beginsWithSubCollection: ''a'''
-			'endsWith1 ''abc'' endsWithSubCollection: ''a''')
+			'beginsWith1 ''abc'' greaseBeginsWith: ''a'''
+			'endsWith1 ''abc'' greaseEndsWith: ''a''')


### PR DESCRIPTION
Instead of removing the tests in https://github.com/SeasideSt/Grease/pull/149, I propose adding new methods that define the new behaviour across all platforms consistenty. See discussion in https://github.com/SeasideSt/Grease/issues/147.

In summary:
- introduce `greaseBeginsWith:` and `greaseEndsWith:` on `SequenceableCollection` which implements the semantics of `beginsWith:` and `endsWith:` such that using an empty argument collections always returns `true`. This is different from the current `beginsWithSubCollection:` and `endsWithSubCollection:` which return `false` when used with an empty argument.
- deprecate `beginsWithSubCollection:` and `endsWithSubCollection:` 