### PR TITLE
update SmalltalkCI github action to use gsdevkit_stones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,22 +4,20 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-10, Pharo64-9.0, Pharo64-8.0, Pharo64-7.0, GemStone64-3.6.3, GemStone64-3.5.7, GemStone64-3.4.5, GemStone64-3.3.9, GemStone64-3.2.17, GemStone64-3.1.0.6, Squeak64-5.3 ]
+        smalltalk: [ Pharo64-11, Pharo64-10, Pharo64-9.0, Pharo64-8.0, Pharo64-7.0, GemStone64-3.6.5, GemStone64-3.5.7, Squeak64-5.3 ]
         experimental: [ false ]
         include:
-          - smalltalk: Pharo64-11
-            experimental: true
           - smalltalk: Squeak64-6.0
             experimental: true
     continue-on-error: ${{ matrix.experimental }}
     name: ${{ matrix.smalltalk }}
     steps:
       - uses: actions/checkout@v3
-      - uses: hpi-swa/setup-smalltalkCI@v1
+      - uses: dalehenrich/setup-smalltalkCI@solo
         with:
           smalltalk-image: ${{ matrix.smalltalk }}
           smalltalkCI-source: 'jbrichau/smalltalkCI'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: dalehenrich/setup-smalltalkCI@solo
         with:
           smalltalk-image: ${{ matrix.smalltalk }}
-          smalltalkCI-source: 'jbrichau/smalltalkCI'
       - name: Run tests
         run: smalltalkci -s ${{ matrix.smalltalk }}
         env:


### PR DESCRIPTION
Github action's ubuntu-18 runner is EoL by April 1st 2023. https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

GemStone versions older than 3.5.x no longer work on ubuntu 20 and beyond. Also, GsDevKit_home no longer works on Ubuntu 20 due to a dependency on 32-bit Pharo. As such, we longer test Grease for versions of GemStone older than the ones in the CI action spec.

This PR switches to the new [gsdevkit](https://github.com/GsDevKit/GsDevKit_stones) project 