### PR TITLE
Support Pharo native Deprecation

### DIFF
--- a/repository/Grease-Pharo100-Core.package/GRPharoPlatform.class/instance/deprecationExceptionSet.st
+++ b/repository/Grease-Pharo100-Core.package/GRPharoPlatform.class/instance/deprecationExceptionSet.st
@@ -1,0 +1,6 @@
+exceptions
+deprecationExceptionSet
+	"Answer the exception set that should considered besides WADeprecation."
+	^ ExceptionSet new
+		add: Deprecation;
+		yourself

--- a/repository/Grease-Pharo70-Core.package/GRPharoPlatform.class/instance/deprecationExceptionSet.st
+++ b/repository/Grease-Pharo70-Core.package/GRPharoPlatform.class/instance/deprecationExceptionSet.st
@@ -1,0 +1,6 @@
+exceptions
+deprecationExceptionSet
+	"Answer the exception set that should considered besides WADeprecation."
+	^ ExceptionSet new
+		add: Deprecation;
+		yourself

--- a/repository/Grease-Pharo90-Core.package/GRPharoPlatform.class/instance/deprecationExceptionSet.st
+++ b/repository/Grease-Pharo90-Core.package/GRPharoPlatform.class/instance/deprecationExceptionSet.st
@@ -1,0 +1,6 @@
+exceptions
+deprecationExceptionSet
+	"Answer the exception set that should considered besides WADeprecation."
+	^ ExceptionSet new
+		add: Deprecation;
+		yourself

--- a/repository/Grease-Tests-Pharo-Core.package/GRPharoPlatformTest.class/instance/testDeprecationExceptionSet.st
+++ b/repository/Grease-Tests-Pharo-Core.package/GRPharoPlatformTest.class/instance/testDeprecationExceptionSet.st
@@ -1,0 +1,10 @@
+tests
+testDeprecationExceptionSet
+	| value |
+	value := [
+		"intentially send Pharo instead of Grease deprecation message"
+		self deprecated: 'test'.
+		'failed' ]
+			on: GRDeprecatedApiNotification, GRPlatform current deprecationExceptionSet
+			do: [ :e | 'passed' ].
+	self assert: value = 'passed'


### PR DESCRIPTION
Implement `#deprecationExceptionSet` for Pharo and add `Deprecation`.

Currently `#deprecationExceptionSet` is empty for Pharo resulting in a nasty stack trace if somebody sends a message that Pharo deprecated, see #179.

![DeprecationMissing](https://github.com/user-attachments/assets/421f6816-17c8-43af-8330-3773824e0e71)

Unfortunately this doesn't actually make `Deprecation` work with the Seaside tools as `Deprecation >> #messageText` results in a MNU. This looks like a Pharo bug to me, I filed https://github.com/pharo-project/pharo/issues/16897.

```
UndefinedObject(Object)>>doesNotUnderstand: #homeMethod
Deprecation>>sendingMethodName
[ :str |
		self shouldTransform ifTrue: [
			str nextPutAll:  'Automatic deprecation code rewrite: '].
		str
			nextPutAll: 'The method ';
			nextPutAll: self deprecatedMethodName;
			nextPutAll: ' called from ';
			nextPutAll: self sendingMethodName;
			nextPutAll: ' has been deprecated. ';
		 	nextPutAll: explanationString] in Deprecation>>messageText in Block: [ :str |...
String class(SequenceableCollection class)>>new:streamContents:
String class(SequenceableCollection class)>>streamContents:
Deprecation>>messageText
[ :each | 
		(each messageText = aNotification messageText)
			and: [ each details = aNotification details ] ] in WADeprecatedToolFilter>>deprecated: in Block: [ :each | ...
OrderedCollection>>reject:
WADeprecatedToolFilter>>deprecated:
[ :notification | self deprecated: notification ] in WADeprecatedToolFilter>>handleFiltered: in Block: [ :notification | self deprecated: notification ]
```