### PR TITLE
Expanded the testcase for GRPlatform>>secureHashFor:

### DIFF
--- a/repository/Grease-Tests-Core.package/GRPlatformTest.class/instance/testSecureHashFor.st
+++ b/repository/Grease-Tests-Core.package/GRPlatformTest.class/instance/testSecureHashFor.st
@@ -1,9 +1,19 @@
 tests
 testSecureHashFor
-	"Make sure the platform class provides a #secureHashFor: method. The method is called by Seaside when hashing passwords. The Squeak implementation returns a SHA-1 hash but another equivalent hash method could also be used."
+	"Make sure the platform class provides a #secureHashFor: method. The method is called by Seaside when hashing passwords. 
+	The Pharo implementation returns a SHA-1 hash but another equivalent hash method could also be used."
 	
-	| a b |
+	| a b c d invalidUtf8 e f |
 	a := self platform secureHashFor: 'foobar'.
 	b := self platform secureHashFor: 'foobar'.
+	self assert: a equals: b.
+
+	c := self platform secureHashFor: #[102 111 111 98 97 114].
+	d := self platform secureHashFor: #[102 111 111 98 97 114].
+	self assert: c equals: d.
 	
-	self assert: (a = b)
+	"The following ensures any byte array can be used (and not only the onces containing valid utf8)"
+	invalidUtf8 := #[160 161].
+	e := self platform secureHashFor: invalidUtf8.
+	f := self platform secureHashFor: invalidUtf8.
+	self assert: e equals: f


### PR DESCRIPTION
The method `GRPlatform>>secureHashFor:` accepts both a `String` and a `ByteArray` as argument. The contents of the `ByteArray` can be any sequence of bytes, so it should not represent a valid UTF8 encoded `String` (for example). 

In this PR, we extend the test case to also cover the use of a `ByteArray`. 

In Seaside, all invocations of the method always passed a `String` instance as argument, until the e-tag implementation for the file libraries, which also uses it to generate a hash for any served file, which may include binary files (e.g. images). See https://github.com/SeasideSt/Seaside/pull/1325.