### PR TITLE
List all platforms grease can be run on

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Grease is widely adopted. Implementations exist already for all platforms that s
 
 ## Platform compatibility
 
-The latest Grease version is supported on the Pharo and GemStone/S  platforms and versions tested in the SmalltalkCI workflow in Github Actions: [![smalltalkCI](https://github.com/SeasideSt/Grease/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/SeasideSt/Grease/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/SeasideSt/Grease/branch/master/graph/badge.svg?token=75NIYAHAGI)](https://codecov.io/gh/SeasideSt/Grease)
+The latest Grease version is supported on the Pharo, GemStone/S, Squeak, and VAST (not part of this repository) platforms and versions tested in the SmalltalkCI workflow in Github Actions: [![smalltalkCI](https://github.com/SeasideSt/Grease/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/SeasideSt/Grease/actions/workflows/ci.yml) [![codecov](https://codecov.io/gh/SeasideSt/Grease/branch/master/graph/badge.svg?token=75NIYAHAGI)](https://codecov.io/gh/SeasideSt/Grease)
 
 ## Installation
 


### PR DESCRIPTION
Updating the the readme file with the information with "which platforms do use grease"