### PR TITLE
Class shouldn't have category starting with * that belongs to extensions

### DIFF
--- a/repository/Grease-GemStone-Core.package/GRGemStonePlatform.class/instance/doTransaction..st
+++ b/repository/Grease-GemStone-Core.package/GRGemStonePlatform.class/instance/doTransaction..st
@@ -1,4 +1,4 @@
-*grease-gemstone-core
+transactions
 doTransaction: aBlock
   "Evaluate aBlock in a transaction. 
 	 Return true if the transaction succeeds and false if the transaction fails.

--- a/repository/Grease-GemStone-Core.package/GRGemStonePlatform.class/instance/thisContext.st
+++ b/repository/Grease-GemStone-Core.package/GRGemStonePlatform.class/instance/thisContext.st
@@ -1,3 +1,3 @@
-*grease-gemstone-core
+processes
 thisContext
   ^ GsContext fromLevel: 3

--- a/repository/Grease-Tests-GemStone-Core.package/GRGemStonePlatformTest.class/instance/testIsGemStone.st
+++ b/repository/Grease-Tests-GemStone-Core.package/GRGemStonePlatformTest.class/instance/testIsGemStone.st
@@ -1,4 +1,4 @@
-*Grease-Tests-Pharo-Core
+tests
 testIsGemStone
 	self assert: GRPlatform current isGemStone.
 	self deny: GRPlatform current isPharo.

--- a/repository/Grease-Tests-GemStone32-Core.package/GRGemStonePlatformTest.class/instance/testIsGemStone.st
+++ b/repository/Grease-Tests-GemStone32-Core.package/GRGemStonePlatformTest.class/instance/testIsGemStone.st
@@ -1,4 +1,4 @@
-*Grease-Tests-Pharo-Core
+tests
 testIsGemStone
 	self assert: GRPlatform current isGemStone.
 	self deny: GRPlatform current isPharo.


### PR DESCRIPTION
Fixing all methods that are in class but have category prefixed with *.  Prefix * is reserved for extensions.