### PR TITLE
Adding pharo asserts to GemStone

### DIFF
--- a/repository/Grease-GemStone-Core.package/TestAsserter.extension/instance/assert.identicalTo..st
+++ b/repository/Grease-GemStone-Core.package/TestAsserter.extension/instance/assert.identicalTo..st
@@ -1,0 +1,4 @@
+*grease-gemstone-core
+assert: anObject identicalTo: otherObj
+
+        self assert: anObject identical: otherObj

--- a/repository/Grease-GemStone-Core.package/TestAsserter.extension/instance/deny.identicalTo..st
+++ b/repository/Grease-GemStone-Core.package/TestAsserter.extension/instance/deny.identicalTo..st
@@ -1,0 +1,5 @@
+*grease-gemstone-core
+deny: anObject identicalTo: anotherObject
+	self
+		deny: anObject == anotherObject
+		description: anObject printString, ' is *not* identical to ', anotherObject printString.

--- a/repository/Grease-GemStone-Core.package/TestAsserter.extension/properties.json
+++ b/repository/Grease-GemStone-Core.package/TestAsserter.extension/properties.json
@@ -1,0 +1,2 @@
+{
+	"name" : "TestAsserter" }


### PR DESCRIPTION
Extending asserts that are present in Pharo, but not in GemStone.  Some libraries have tests that are using those.  Adding these "aliases" will prevent test code duplication.