### PR TITLE
GRSlime rules inherit from the RB rules thus are incorrectly identified

### DIFF
--- a/repository/Grease-Pharo110-Slime-Core.package/GRSlimeBlockLintRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Pharo110-Slime-Core.package/GRSlimeBlockLintRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeBlockLintRule'

--- a/repository/Grease-Pharo110-Slime-Core.package/GRSlimeParseTreeLintRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Pharo110-Slime-Core.package/GRSlimeParseTreeLintRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeParseTreeLintRule'

--- a/repository/Grease-Pharo110-Slime-Core.package/GRSlimeTransformationRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Pharo110-Slime-Core.package/GRSlimeTransformationRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeTransformationRule'

--- a/repository/Grease-Pharo40-Slime.package/GRSlimeBlockLintRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Pharo40-Slime.package/GRSlimeBlockLintRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeBlockLintRule'

--- a/repository/Grease-Pharo40-Slime.package/GRSlimeParseTreeLintRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Pharo40-Slime.package/GRSlimeParseTreeLintRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeParseTreeLintRule'

--- a/repository/Grease-Pharo40-Slime.package/GRSlimeTransformationRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Pharo40-Slime.package/GRSlimeTransformationRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeTransformationRule'

--- a/repository/Grease-Pharo90-Slime.package/GRSlimeBlockLintRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Pharo90-Slime.package/GRSlimeBlockLintRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeBlockLintRule'

--- a/repository/Grease-Pharo90-Slime.package/GRSlimeParseTreeLintRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Pharo90-Slime.package/GRSlimeParseTreeLintRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeParseTreeLintRule'

--- a/repository/Grease-Pharo90-Slime.package/GRSlimeTransformationRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Pharo90-Slime.package/GRSlimeTransformationRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeTransformationRule'

--- a/repository/Grease-Slime.package/GRSlimeBlockLintRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Slime.package/GRSlimeBlockLintRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeBlockLintRule'

--- a/repository/Grease-Slime.package/GRSlimeParseTreeLintRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Slime.package/GRSlimeParseTreeLintRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeParseTreeLintRule'

--- a/repository/Grease-Slime.package/GRSlimeTransformationRule.class/class/uniqueIdentifierName.st
+++ b/repository/Grease-Slime.package/GRSlimeTransformationRule.class/class/uniqueIdentifierName.st
@@ -1,0 +1,4 @@
+accessing
+uniqueIdentifierName
+	"This identifier should be unique. Should change only when the rule completely change semantics."
+	^ 'SlimeTransformationRule'


### PR DESCRIPTION
Pharo uses unique identifier to identify rule class.  Since GRSlime rules inherit from RB rules they inherit also their unique identifier. This patch creates unique identifier for the GRSlime classes.

For more information see test ReSmallLintTest>>testUniqueIdentifierName in Pharo