### PR TITLE
Removing trailing space from protocol name as it can cause nasty issues

### DIFF
--- a/repository/Grease-Core.package/GROrderedMultiMap2.class/instance/privateAllAt.startingAt..st
+++ b/repository/Grease-Core.package/GROrderedMultiMap2.class/instance/privateAllAt.startingAt..st
@@ -1,4 +1,4 @@
-private 
+private
 privateAllAt: aKey startingAt: index
 	^ Array new: 2 streamContents: [ :stream |
 		index to: size * 2 - 1 by: 2 do: [ :i |

--- a/repository/Grease-Core.package/GRSmallOrderedSet.class/instance/errorNotFound.st
+++ b/repository/Grease-Core.package/GRSmallOrderedSet.class/instance/errorNotFound.st
@@ -1,3 +1,3 @@
-private 
+private
 errorNotFound
 	self error: 'Not found'

--- a/repository/Grease-Core.package/GRSmallOrderedSet.class/instance/findIndexFor..st
+++ b/repository/Grease-Core.package/GRSmallOrderedSet.class/instance/findIndexFor..st
@@ -1,4 +1,4 @@
-private 
+private
 findIndexFor: aKey
 	1 to: size do: [ :index |
 		(table at: index) = aKey

--- a/repository/Grease-Core.package/GRSmallOrderedSet.class/instance/grow.st
+++ b/repository/Grease-Core.package/GRSmallOrderedSet.class/instance/grow.st
@@ -1,4 +1,4 @@
-private 
+private
 grow
 	| newTable |
 	"#replaceFrom:to:with:startingAt: would be better but not portable"

--- a/repository/Grease-Core.package/GRSmallOrderedSet.class/instance/privateAdd..st
+++ b/repository/Grease-Core.package/GRSmallOrderedSet.class/instance/privateAdd..st
@@ -1,4 +1,4 @@
-private 
+private
 privateAdd: newObject
 	size = table size ifTrue: [ self grow ].
 	table at: (size := size + 1) put: newObject

--- a/repository/Grease-Core.package/GRSmallOrderedSet.class/instance/removeIndex..st
+++ b/repository/Grease-Core.package/GRSmallOrderedSet.class/instance/removeIndex..st
@@ -1,4 +1,4 @@
-private 
+private
 removeIndex: index
 	table at: index put: nil.
 	index to: size - 1 do: [ :i |


### PR DESCRIPTION
For example, in GemStone you can have two protocols with the same name but one will not work properly.  All because of the space in the protocol name