### PR TITLE
Adding a needed method for SocketStream in GemStone

### DIFF
--- a/repository/Grease-GemStone-Core.package/SocketStream.extension/instance/greaseNext.putAll.startingAt..st
+++ b/repository/Grease-GemStone-Core.package/SocketStream.extension/instance/greaseNext.putAll.startingAt..st
@@ -1,0 +1,13 @@
+*grease-gemstone-core
+greaseNext: anInteger putAll: aCollection startingAt: startIndex
+	"Put a String or a ByteArray onto the stream starting at the given position.
+	Currently a large collection will allocate a large buffer."
+
+	| toPut |
+	anInteger = 0 ifTrue: [
+		^ aCollection ].
+	toPut := binary ifTrue: [ aCollection asByteArray ] ifFalse: [ aCollection asString ].
+	self adjustOutBuffer: anInteger.
+	outBuffer replaceFrom: outNextToWrite to: outNextToWrite + anInteger - 1 with: toPut startingAt: startIndex.
+	outNextToWrite := outNextToWrite + anInteger.
+	self checkFlush

--- a/repository/Grease-GemStone-Core.package/SocketStream.extension/properties.json
+++ b/repository/Grease-GemStone-Core.package/SocketStream.extension/properties.json
@@ -1,0 +1,3 @@
+{
+	"name" : "SocketStream"
+}


### PR DESCRIPTION
This method is in Pharo package.  Since GemStone is using SocketStream too it needs it.